### PR TITLE
Fix consentform restore for course overview agreement

### DIFF
--- a/backup/moodle2/backup_consentform_activity_task.class.php
+++ b/backup/moodle2/backup_consentform_activity_task.class.php
@@ -69,6 +69,10 @@ class backup_consentform_activity_task extends backup_activity_task {
         $search = '/('.$base.'\/mod\/consentform\/view.php\?id\=)([0-9]+)/';
         $content = preg_replace($search, '$@NEWMODULEVIEWBYID*$2@$', $content);
 
+        // Link to consentform confirmation by instanceid.
+        $search = '/('.$base.'\/mod\/consentform\/confirmation.php\?id\=)([0-9]+)/';
+        $content = preg_replace($search, '$@NEWCONSENTFORMCONFIRMATION*$2@$', $content);
+
         return $content;
     }
 }

--- a/backup/moodle2/backup_consentform_stepslib.php
+++ b/backup/moodle2/backup_consentform_stepslib.php
@@ -67,6 +67,7 @@ class backup_consentform_activity_structure_step extends backup_activity_structu
 
         // Define file annotations.
         $consentform->annotate_files('mod_consentform', 'intro', null);
+        $consentform->annotate_files('mod_consentform', 'consentform', null);
 
         // Return the root element (consentform), wrapped into standard activity structure.
         return $this->prepare_activity_structure($consentform);

--- a/backup/moodle2/restore_consentform_activity_task.class.php
+++ b/backup/moodle2/restore_consentform_activity_task.class.php
@@ -76,6 +76,11 @@ class restore_consentform_activity_task extends restore_activity_task {
 
         $rules[] = new restore_decode_rule('NEWMODULEVIEWBYID', '/mod/consentform/view.php?id=$1', 'course_module');
         $rules[] = new restore_decode_rule('NEWMODULEINDEX', '/mod/consentform/index.php?id=$1', 'course');
+        $rules[] = new restore_decode_rule(
+            'NEWCONSENTFORMCONFIRMATION',
+            '/mod/consentform/confirmation.php?id=$1',
+            'consentform'
+        );
 
         return $rules;
 

--- a/backup/moodle2/restore_consentform_stepslib.php
+++ b/backup/moodle2/restore_consentform_stepslib.php
@@ -23,6 +23,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+require_once($CFG->dirroot . '/mod/consentform/lib.php');
+
 /**
  * Structure step to restore one consentform activity
  *
@@ -85,8 +87,8 @@ class restore_consentform_activity_structure_step extends restore_activity_struc
         // Create the consentform instance.
         $newitemid = $DB->insert_record('consentform', $data);
         if ($data->confirmincourseoverview) {
-            $data->intro = str_replace("confirmation.php?id=".$data->id, "confirmation.php?id=".$newitemid, $data->intro);
             $data->id = $newitemid;
+            $data->intro = consentform_get_courseoverview_iframe((int) $newitemid);
             $DB->update_record('consentform', $data);
         }
         $this->newcfid = $newitemid;
@@ -106,10 +108,14 @@ class restore_consentform_activity_structure_step extends restore_activity_struc
         $data = (object) $data;
         $oldid = $data->id;
 
-        $moduleid = $DB->get_field('course_modules', 'module', ['id' => $data->consentformcmid]);
-        $newcmid = $DB->get_field('course_modules', 'id',
-            ['module' => $moduleid, 'instance' => $this->newcfid]);
+        $newcmid = $this->get_mappingid('course_module', $data->consentformcmid);
+        $newuserid = $this->get_mappingid('user', $data->userid);
+        if (empty($newcmid) || empty($newuserid)) {
+            return;
+        }
+
         $data->consentformcmid = $newcmid;
+        $data->userid = $newuserid;
 
         $newitemid = $DB->insert_record('consentform_state', $data);
         $this->set_mapping('consentformstate', $oldid, $newitemid);
@@ -121,5 +127,6 @@ class restore_consentform_activity_structure_step extends restore_activity_struc
     protected function after_execute() {
         // Add consentform related files, no need to match by itemname (just internally handled context).
         $this->add_related_files('mod_consentform', 'intro', null);
+        $this->add_related_files('mod_consentform', 'consentform', null);
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -43,6 +43,30 @@ define('CONSENTFORM_DEFAULTCSSCLASS_INLINE', 'consentform_confirmationtext_incou
 /* Moodle core API */
 
 /**
+ * Builds the iframe used when agreement is shown directly in the course overview.
+ *
+ * @param int $consentformid Consentform instance id.
+ * @return string
+ */
+function consentform_get_courseoverview_iframe(int $consentformid): string {
+    global $CFG;
+
+    $iframeparms = [];
+    $iframeparms['src'] = $CFG->wwwroot . '/mod/consentform/confirmation.php?id=' . $consentformid;
+    $iframeparms['scrolling'] = 'auto';
+    $js = "this.contentWindow.document.getElementById('page').style.marginTop='0px';";
+    $js .= "this.contentWindow.document.getElementById('page').style.marginBottom='0px';";
+    $js .= "this.contentWindow.document.getElementById('page-content').classList.remove('pb-3');";
+    $js .= "this.style.height=this.contentWindow.document.documentElement.scrollHeight + 'px';";
+    $iframeparms['onload'] = $js;
+    $iframeparms['frameborder'] = '0';
+    $iframeparms['class'] = 'w-100';
+    $iframeparms['name'] = 'consentformiframe' . $consentformid;
+
+    return html_writer::tag('iframe', null, $iframeparms);
+}
+
+/**
  * Returns the information on whether the module supports a feature
  *
  * See plugin_supports() for more info.
@@ -89,7 +113,7 @@ function consentform_supports($feature) {
  * @return int The id of the newly inserted consentform record
  */
 function consentform_add_instance(stdClass $consentform, mod_consentform_mod_form $mform = null) {
-    global $DB, $CFG;
+    global $DB;
 
     $cmid = $consentform->coursemodule;
 
@@ -101,20 +125,7 @@ function consentform_add_instance(stdClass $consentform, mod_consentform_mod_for
     $consentform->id = $DB->insert_record('consentform', $consentform);
 
     if ($consentform->confirmincourseoverview) {
-        $iframeparms = [];
-        $url = $CFG->wwwroot."/mod/consentform/confirmation.php?id=".$consentform->id;
-        $iframeparms["src"] = $url;
-        $iframeparms["scrolling"] = "auto";
-        $js = "this.contentWindow.document.getElementById('page').style.marginTop='0px';";
-        $js .= "this.contentWindow.document.getElementById('page').style.marginBottom='0px';";
-        $js .= "this.contentWindow.document.getElementById('page-content').classList.remove('pb-3');";
-        $js .= "this.style.height=this.contentWindow.document.documentElement.scrollHeight + 'px';";
-        $iframeparms["onload"] = $js;
-        $iframeparms["frameborder"] = "0";
-        $iframeparms["class"] = "w-100";
-        $iframeparms["name"] = "consentformiframe$consentform->id";
-        $html = html_writer::tag("iframe", null, $iframeparms);
-        $consentform->intro = $html;
+        $consentform->intro = consentform_get_courseoverview_iframe((int) $consentform->id);
     }
 
     if ($consentform->usegrade) {
@@ -185,6 +196,10 @@ function consentform_update_instance(stdClass $consentform, mod_consentform_mod_
             consentform_get_editor_options($context),
             $consentform->confirmationtext_editor['text']
         );
+    }
+
+    if ($consentformdb->confirmincourseoverview) {
+        $consentform->intro = consentform_get_courseoverview_iframe((int) $consentform->id);
     }
 
     $result = $DB->update_record('consentform', $consentform);
@@ -460,4 +475,3 @@ function consentform_pluginfile($course, $cm, $context, $filearea, $args, $force
     // Finally send the file.
     send_stored_file($file, null, 0, $forcedownload, $options);
 }
-

--- a/tests/backup_restore_test.php
+++ b/tests/backup_restore_test.php
@@ -1,0 +1,260 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Backup and restore tests for mod_consentform.
+ *
+ * @package    mod_consentform
+ * @copyright  2026 Wunderbyte GmbH <info@wunderbyte.at>
+ * @author     Mahdi Poustini
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+require_once($CFG->dirroot . '/course/modlib.php');
+require_once($CFG->dirroot . '/mod/consentform/lib.php');
+
+/**
+ * Backup and restore tests for mod_consentform.
+ *
+ * @package    mod_consentform
+ * @copyright  2026 Wunderbyte GmbH <info@wunderbyte.at>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class mod_consentform_backup_restore_test extends advanced_testcase {
+
+    /**
+     * Course overview iframe is regenerated with the target site's URL and new instance id.
+     */
+    public function test_course_overview_iframe_is_regenerated_on_restore(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $CFG->enablecompletion = true;
+
+        $sourcewwwroot = 'https://source.example.test/moodle';
+        $targetwwwroot = 'https://target.example.test/moodle';
+        $CFG->wwwroot = $sourcewwwroot;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => COMPLETION_ENABLED]);
+        $consentform = $this->create_consentform($course, ['confirmincourseoverview' => 1]);
+
+        $sourceintro = $DB->get_field('consentform', 'intro', ['id' => $consentform->id], MUST_EXIST);
+        $this->assertStringContainsString(
+            $sourcewwwroot . '/mod/consentform/confirmation.php?id=' . $consentform->id,
+            $sourceintro
+        );
+
+        $backupid = $this->backup_course($course);
+        $CFG->wwwroot = $targetwwwroot;
+        $newcourseid = $this->restore_course($backupid, $course);
+
+        $restored = $DB->get_record('consentform', ['course' => $newcourseid], '*', MUST_EXIST);
+        $this->assertNotEquals($consentform->id, $restored->id);
+        $this->assertStringContainsString(
+            $targetwwwroot . '/mod/consentform/confirmation.php?id=' . $restored->id,
+            $restored->intro
+        );
+        $this->assertStringNotContainsString($sourcewwwroot, $restored->intro);
+        $this->assertStringNotContainsString('confirmation.php?id=' . $consentform->id, $restored->intro);
+    }
+
+    /**
+     * Files embedded in the confirmation text are included in the restored module context.
+     */
+    public function test_confirmationtext_files_are_restored(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $CFG->enablecompletion = true;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => COMPLETION_ENABLED]);
+        $consentform = $this->create_consentform($course);
+        $sourcecontext = context_module::instance($consentform->cmid);
+
+        $fs = get_file_storage();
+        $fs->create_file_from_string([
+            'contextid' => $sourcecontext->id,
+            'component' => 'mod_consentform',
+            'filearea' => 'consentform',
+            'itemid' => 0,
+            'filepath' => '/',
+            'filename' => 'terms.txt',
+        ], 'Restored terms');
+
+        $backupid = $this->backup_course($course);
+        $newcourseid = $this->restore_course($backupid, $course);
+        $restored = $DB->get_record('consentform', ['course' => $newcourseid], '*', MUST_EXIST);
+        $restoredcm = get_coursemodule_from_instance('consentform', $restored->id, $newcourseid, false, MUST_EXIST);
+        $restoredcontext = context_module::instance($restoredcm->id);
+
+        $restoredfile = $fs->get_file($restoredcontext->id, 'mod_consentform', 'consentform', 0, '/', 'terms.txt');
+        $this->assertNotFalse($restoredfile);
+        $this->assertEquals('Restored terms', $restoredfile->get_content());
+    }
+
+    /**
+     * User agreement state is restored against the restored course module id.
+     */
+    public function test_consentform_state_uses_restored_course_module_mapping(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $CFG->enablecompletion = true;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => COMPLETION_ENABLED]);
+        $user = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id, 'student');
+        $consentform = $this->create_consentform($course);
+
+        $DB->insert_record('consentform_state', [
+            'consentformcmid' => $consentform->cmid,
+            'userid' => $user->id,
+            'state' => CONSENTFORM_STATUS_AGREED,
+            'timestamp' => time(),
+        ]);
+
+        $backupid = $this->backup_course($course, true);
+        $newcourseid = $this->restore_course($backupid, $course, true);
+        $restored = $DB->get_record('consentform', ['course' => $newcourseid], '*', MUST_EXIST);
+        $restoredcm = get_coursemodule_from_instance('consentform', $restored->id, $newcourseid, false, MUST_EXIST);
+
+        $state = $DB->get_record('consentform_state', [
+            'consentformcmid' => $restoredcm->id,
+            'userid' => $user->id,
+        ], '*', MUST_EXIST);
+
+        $this->assertEquals(CONSENTFORM_STATUS_AGREED, $state->state);
+        $this->assertNotEquals($consentform->cmid, $state->consentformcmid);
+    }
+
+    /**
+     * Creates a consentform activity without requiring a plugin data generator.
+     *
+     * @param stdClass $course Course record.
+     * @param array $overrides Field overrides.
+     * @return stdClass Consentform record with cmid.
+     */
+    private function create_consentform(stdClass $course, array $overrides = []): stdClass {
+        global $DB;
+
+        $moduleinfo = (object) array_merge([
+            'modulename' => 'consentform',
+            'module' => $DB->get_field('modules', 'id', ['name' => 'consentform'], MUST_EXIST),
+            'course' => $course->id,
+            'section' => 0,
+            'visible' => 1,
+            'visibleoncoursepage' => 1,
+            'name' => 'Consent form',
+            'intro' => '',
+            'introformat' => FORMAT_HTML,
+            'confirmationtext' => '<p>Please confirm.</p>',
+            'textagreementbutton' => 'Agree',
+            'textrefusalbutton' => 'Refuse',
+            'textrevocationbutton' => 'Revoke',
+            'optionrevoke' => 0,
+            'optionrefuse' => 0,
+            'usegrade' => 0,
+            'confirmincourseoverview' => 0,
+            'nocoursemoduleslist' => 0,
+            'cssclassesstring' => '',
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'completionview' => 0,
+            'completionexpected' => 0,
+            'completionpassgrade' => 0,
+            'showdescription' => 1,
+            'cmidnumber' => '',
+        ], $overrides);
+
+        $moduleinfo = add_moduleinfo($moduleinfo, $course);
+        $consentform = $DB->get_record('consentform', ['id' => $moduleinfo->instance], '*', MUST_EXIST);
+        $consentform->cmid = $moduleinfo->coursemodule;
+
+        return $consentform;
+    }
+
+    /**
+     * Backs up a course and returns the generated backup id.
+     *
+     * @param stdClass $course Course record.
+     * @param bool $userdata Whether to include user data.
+     * @return string Backup id.
+     */
+    private function backup_course(stdClass $course, bool $userdata = false): string {
+        global $CFG, $USER;
+
+        $CFG->backup_file_logger_level = backup::LOG_NONE;
+
+        $bc = new backup_controller(
+            backup::TYPE_1COURSE,
+            $course->id,
+            backup::FORMAT_MOODLE,
+            backup::INTERACTIVE_NO,
+            backup::MODE_IMPORT,
+            $USER->id
+        );
+        $bc->get_plan()->get_setting('users')->set_status(backup_setting::NOT_LOCKED);
+        $bc->get_plan()->get_setting('users')->set_value($userdata);
+
+        $backupid = $bc->get_backupid();
+        $bc->execute_plan();
+        $bc->destroy();
+
+        return $backupid;
+    }
+
+    /**
+     * Restores a backup into a new course.
+     *
+     * @param string $backupid Backup id.
+     * @param stdClass $sourcecourse Source course record.
+     * @param bool $userdata Whether to include user data.
+     * @return int Restored course id.
+     */
+    private function restore_course(string $backupid, stdClass $sourcecourse, bool $userdata = false): int {
+        global $USER;
+
+        $newcourseid = restore_dbops::create_new_course(
+            $sourcecourse->fullname,
+            $sourcecourse->shortname . '_restored' . random_string(4),
+            $sourcecourse->category
+        );
+
+        $rc = new restore_controller(
+            $backupid,
+            $newcourseid,
+            backup::INTERACTIVE_NO,
+            backup::MODE_GENERAL,
+            $USER->id,
+            backup::TARGET_NEW_COURSE
+        );
+        $rc->get_plan()->get_setting('users')->set_status(backup_setting::NOT_LOCKED);
+        $rc->get_plan()->get_setting('users')->set_value($userdata);
+
+        $this->assertTrue($rc->execute_precheck());
+        $rc->execute_plan();
+        $rc->destroy();
+
+        return $newcourseid;
+    }
+}


### PR DESCRIPTION
 Regenerate the course-overview confirmation iframe during restore so it
  uses the target Moodle site's wwwroot and restored consentform id.

  Also include confirmation text files in backup/restore and restore
  consentform_state records using Moodle's course module and user mappings.

  Refs: academic-moodle-cooperation/moodle-mod_consentform#13